### PR TITLE
When receiving an unexpected verb, bad errors are generated

### DIFF
--- a/lib/restiq.js
+++ b/lib/restiq.js
@@ -336,11 +336,13 @@ Restiq.prototype.mapRoute = function mapRoute( method, url ) {
         var mappedRoute;
         var routeName = method.toUpperCase() + '::' + url;
         mappedRoute = this._routes.Other.mapRoute(routeName)
-        // strip off our prepended extra routing info
-        mappedRoute.path = mappedRoute.path.slice(method.length + 2);
-        // route.name is almost redundant, but route._route.name has
-        // the prepended METHOD:: prefix, while route.name does not
-        mappedRoute.name = mappedRoute.name.slice(method.length + 2);
+        if (mappedRoute) {
+            // strip off our prepended extra routing info
+            mappedRoute.path = mappedRoute.path.slice(method.length + 2);
+            // route.name is almost redundant, but route._route.name has
+            // the prepended METHOD:: prefix, while route.name does not
+            mappedRoute.name = mappedRoute.name.slice(method.length + 2);
+        }
         return mappedRoute;
     }
 };


### PR DESCRIPTION
I was testing a very simple implementation of Restiq that simply
answered for "GET /", then I threw a "PUT /blah" at it, causing this
message:

    TypeError: Cannot read property 'path' of undefined
        at Restiq.mapRoute
        (/.../node_modules/restiq/lib/restiq.js:347:39)

Wrapping these two statements in an `if` statement solves the problem
and the mapRoute function shall still properly return `undefined` when
there is no route for that method.