### PR TITLE
Ignore the directory added by npm (try #2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+/.nyc_output/
+/coverage/


### PR DESCRIPTION
Same pull request as #1, but I have the commits split up so you can accept them individually as pull requests.

This ignores `/npm_modules/` in the root of the repository because one can checkout the code and then run `npm install` to get dependencies.  It is best to ignore generated files to prevent problems by people accidentally committing them later.