### PR TITLE
Added maxBodySize option which required middleware factories

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -280,7 +280,8 @@ params can be gotten with `app.mw.parseQueryParams()`.
 restiq.mw
 ---------
 
-A library of pre-written middleware utility functions.
+A library of pre-written middleware utility functions. All middleware is
+additionally exposed as a factory.
 
 ### restiq.mw.parseQueryParams( req, res, next )
 
@@ -304,12 +305,61 @@ Gather up the message that was sent with the http request, and save it in
 `req.body`.  This call is safe to call more than once, but sets body only the
 first time.
 
+### restiq.mw.discardBody( req, res, next )
+
+Reads and discards request body forcing the end event on the request.
+
 ### restiq.mw.skipBody( req, res, next )
 
 If the request body is guaranteed to be empty, it is faster to skip waiting
 for the `on('end')` event.  Be careful when using this:  if the request has a
 body it needs to be consumed.
 
+### restiq.mw.buildReadBody(options)
+
+Returns `restiq.mw.readBody`.
+
+#### options
+
+`maxBodySize` - The maximum request body size to enforce. If this is a number, then the value specifies the number of
+bytes; if it is a string, the value is parsed by bytes. Defaults to '100kb'. Exceeding this value results in a
+`400 BadRequest` error response.
+
+### restiq.mw.buildParseBody(options)
+
+Returns `restiq.mw.parseBody`.
+
+#### options
+
+`maxBodySize` - The maximum request body size to enforce. If this is a number, then the value specifies the number of
+bytes; if it is a string, the value is parsed by bytes. Defaults to '100kb'. Exceeding this value results in a
+`400 BadRequest` error response.
+
+### restiq.mw.buildParseBodyParams(options)
+
+Returns `restiq.mw.parseBodyParams`.
+
+#### options
+
+`maxBodySize` - The maximum request body size to enforce. If this is a number, then the value specifies the number of
+bytes; if it is a string, the value is parsed by bytes. Defaults to '100kb'. Exceeding this value results in a
+`400 BadRequest` error response.
+
+### restiq.mw.buildParseQueryParams()
+
+Returns `restiq.mw.parseQueryParams`.
+
+### restiq.mw.buildParseRouteParams()
+
+Returns `restiq.mw.parseRouteParams`.
+
+### restiq.mw.buildDiscardBody()
+
+Returns `restiq.mw.discardBody`.
+
+### restiq.mw.buildSkipBody()
+
+Returns `restiq.mw.skipBody`.
 
 Restify Compatibility Layer
 ---------------------------
@@ -482,8 +532,6 @@ Todo
 - compat: emit restify error events, see http://mcavage.me/node-restify/ #Server+Api
 - compat: expose address(), listen(), close()
 - compat: make parsed query params available in req.query
-- ? make readBody support a max body size limit ?
-- ? offer mw step builders, to accept params?  eg mw.buildReadBody({maxBodySize: 1000}) vs mw.readBody;
 - speed: time w/ bunyan vs w/ qlogger (close, 1820 vs 1750 4% restiq, 1177 vs 1066 8% restify)
 - revisit send(), support headers
 - make addStep() support array of GET, POST etc methods

--- a/Readme.md
+++ b/Readme.md
@@ -321,9 +321,7 @@ Returns `restiq.mw.readBody`.
 
 #### options
 
-`maxBodySize` - The maximum request body size to enforce. If this is a number, then the value specifies the number of
-bytes; if it is a string, the value is parsed by bytes. Defaults to '100kb'. Exceeding this value results in a
-`400 BadRequest` error response.
+`maxBodySize` - The maximum request body size to enforce in bytes. Exceeding this value results in a `400 BadRequest` error response. There is no limit set by default.
 
 ### restiq.mw.buildParseBody(options)
 
@@ -331,9 +329,7 @@ Returns `restiq.mw.parseBody`.
 
 #### options
 
-`maxBodySize` - The maximum request body size to enforce. If this is a number, then the value specifies the number of
-bytes; if it is a string, the value is parsed by bytes. Defaults to '100kb'. Exceeding this value results in a
-`400 BadRequest` error response.
+`maxBodySize` - The maximum request body size to enforce in bytes. Exceeding this value results in a `400 BadRequest` error response. There is no limit set by default.
 
 ### restiq.mw.buildParseBodyParams(options)
 
@@ -341,9 +337,7 @@ Returns `restiq.mw.parseBodyParams`.
 
 #### options
 
-`maxBodySize` - The maximum request body size to enforce. If this is a number, then the value specifies the number of
-bytes; if it is a string, the value is parsed by bytes. Defaults to '100kb'. Exceeding this value results in a
-`400 BadRequest` error response.
+`maxBodySize` - The maximum request body size to enforce in bytes. Exceeding this value results in a `400 BadRequest` error response. There is no limit set by default
 
 ### restiq.mw.buildParseQueryParams()
 

--- a/Readme.md
+++ b/Readme.md
@@ -315,7 +315,7 @@ options
 
 ### restiq.mw.discardBody( req, res, next )
 
-Reads and discards request body to force the end event on the request.
+Reads and discards request body to force the `end` event on the request.
 `buildDiscardBody` returns this middleware function.
 
 ### restiq.mw.skipBody( req, res, next )

--- a/Readme.md
+++ b/Readme.md
@@ -281,23 +281,25 @@ restiq.mw
 ---------
 
 A library of pre-written middleware utility functions. All middleware is
-additionally exposed as a factory.
+also exposed through a configurable factory function.
 
 ### restiq.mw.parseQueryParams( req, res, next )
 
-Merge the query string parameters into `req.params`.
+Merge the query string parameters into `req.params`. `buildParseQueryParams()`
+returns this middleware function.
 
 ### restiq.mw.parseRouteParams( req, res, next )
 
 Merge the parameters embedded in the request path into `req.params`.  This is
 done automatically as soon as the route is mapped, but explicit param parsing
 can override these values.  Re-merging allows control of the param source
-precedence.
+precedence. `buildParseRouteParams()` returns this middleware function.
 
 ### restiq.mw.parseBodyParams( req, res, next )
 
 Merge the query string parameters from the body into `req.params`.  Will read
 the body with `restiq.mw.readBody` if it has not been read already.
+`buildParseBodyParams()` returns this middleware function.
 
 ### restiq.mw.readBody( req, res, next )
 
@@ -305,55 +307,23 @@ Gather up the message that was sent with the http request, and save it in
 `req.body`.  This call is safe to call more than once, but sets body only the
 first time.
 
+`buildReadBodyParams(options)` returns the readBody middleware function.
+
+options
+
+`maxBodySize` - The maximum request body size to enforce in bytes. Exceeding this value results in a `400 BadRequest` error response. There is no limit set by default.
+
 ### restiq.mw.discardBody( req, res, next )
 
-Reads and discards request body forcing the end event on the request.
+Reads and discards request body to force the end event on the request.
+`buildDiscardBody` returns this middleware function.
 
 ### restiq.mw.skipBody( req, res, next )
 
 If the request body is guaranteed to be empty, it is faster to skip waiting
 for the `on('end')` event.  Be careful when using this:  if the request has a
-body it needs to be consumed.
+body it needs to be consumed. `buildSkipBody` returns this middleware function.
 
-### restiq.mw.buildReadBody(options)
-
-Returns `restiq.mw.readBody`.
-
-#### options
-
-`maxBodySize` - The maximum request body size to enforce in bytes. Exceeding this value results in a `400 BadRequest` error response. There is no limit set by default.
-
-### restiq.mw.buildParseBody(options)
-
-Returns `restiq.mw.parseBody`.
-
-#### options
-
-`maxBodySize` - The maximum request body size to enforce in bytes. Exceeding this value results in a `400 BadRequest` error response. There is no limit set by default.
-
-### restiq.mw.buildParseBodyParams(options)
-
-Returns `restiq.mw.parseBodyParams`.
-
-#### options
-
-`maxBodySize` - The maximum request body size to enforce in bytes. Exceeding this value results in a `400 BadRequest` error response. There is no limit set by default
-
-### restiq.mw.buildParseQueryParams()
-
-Returns `restiq.mw.parseQueryParams`.
-
-### restiq.mw.buildParseRouteParams()
-
-Returns `restiq.mw.parseRouteParams`.
-
-### restiq.mw.buildDiscardBody()
-
-Returns `restiq.mw.discardBody`.
-
-### restiq.mw.buildSkipBody()
-
-Returns `restiq.mw.skipBody`.
 
 Restify Compatibility Layer
 ---------------------------

--- a/lib/restiq.js
+++ b/lib/restiq.js
@@ -232,7 +232,7 @@ function finishMiddlewareStack(app, req, res, err) {
     if (err) return app._endWithError(req, res, err);
 
     // fully consume request body, for connection reuse
-    if (!req._bodyEof) app.mw.readBody(req, res);
+    if (!req._bodyEof) app.mw.discardBody(req, res);
 
     // TODO: what route to emit?
     // TODO: can end here before routing, when no route will be set!
@@ -250,7 +250,7 @@ Restiq.prototype._endWithError = function _endWithError( req, res, err, next ) {
     // be sure to consume all input, even in case of error.
     // Either that, or close the connection and force the client to reconnect.
     // TODO: or ensure that http skips the rest of the body
-    if (!req._bodyEof) this.mw.readBody(req, res);
+    if (!req._bodyEof) this.mw.discardBody(req, res);
 
     if (this._errorHandler) {
         this._errorHandler(req, res, err, function(err) {

--- a/lib/rlib.js
+++ b/lib/rlib.js
@@ -9,7 +9,6 @@ var querystring = require('querystring');
 var http_build_query = require('qhttp/http_build_query');
 var http_parse_query = require('qhttp/http_parse_query');
 var Restiq = require('./restiq');
-var bytes = require("bytes");
 
 module.exports = (function() {
     var paramDecoders = {
@@ -189,12 +188,6 @@ module.exports = (function() {
     function buildReadBody(options) {
         options = options || {};
 
-        // Default maxBodySize to 100kb if not passed in.
-        // If it is not a number send it to bytes for parsing.
-        if (typeof options.maxBodySize !== "number") {
-            options.maxBodySize = bytes.parse(options.maxBodySize || "100kb");
-        }
-
         return function readBody( req, res, next ) {
             // body is read only once ever, and _bodyEof is the mutex
             if (req._bodyEof !== undefined) return next ? next() : null;
@@ -226,7 +219,7 @@ module.exports = (function() {
                 // NOTE: toString('binary') is not binary, it converts from latin-1
                 bytesReceived += chunk.length;
 
-                if (bytesReceived > options.maxBodySize) {
+                if (options.maxBodySize && bytesReceived > options.maxBodySize) {
                     req._bodyEof = true;
                     readErr = new Restiq.errors.ErrorBadRequest('Error reading body, max request body size exceeded.');
 

--- a/lib/rlib.js
+++ b/lib/rlib.js
@@ -135,7 +135,7 @@ module.exports = (function() {
             req.on('data', function() {});
             req.on('error', function(err) {
                 req._bodyEof = true;
-                var msg = "Error atempting to dispose the request body" + (req.restiq._opts.debug ? (": " + err.stack) : "");
+                var msg = "Error attempting to dispose the request body" + (req.restiq._opts.debug ? (": " + err.stack) : "");
                 if (next) next(new Restiq.errors.ErrorInternalServerError(msg));
             });
             req.on('end', function() {
@@ -193,13 +193,13 @@ module.exports = (function() {
             if (req._bodyEof !== undefined) return next ? next() : null;
             req._bodyEof = false;
 
-            var readErr;
             var bytesReceived = 0;
             var data = "";
             var databuf;
             //var chunks = new Array();
             var readBinary = req.restiq._opts.readBinary;
             var readImmediate = req.restiq._opts.readImmediate;
+            var _returned = false;
 
             // have the system deal with not splitting multi-byte chars
             if (!readBinary) req.setEncoding('utf8');
@@ -214,16 +214,20 @@ module.exports = (function() {
                 // TODO: find an efficient way of combining contents,
                 // eg preallocate space and copy data into it.
             }
+            function returnOnce( err ) {
+                if (!_returned) {
+                    _returned = true;
+                    if (next) next(err);
+                }
+            }
             function gatherChunk(chunk) {
                 // NOTE: it is faster to concat strings than to push the buffers
                 // NOTE: toString('binary') is not binary, it converts from latin-1
                 bytesReceived += chunk.length;
 
                 if (options.maxBodySize && bytesReceived > options.maxBodySize) {
-                    req._bodyEof = true;
-                    readErr = new Restiq.errors.ErrorBadRequest('Error reading body, max request body size exceeded.');
-
-                    return;
+                    var readErr = new Restiq.errors.ErrorBadRequest('Error reading body, max request body size exceeded.');
+                    returnOnce(readErr);
                 }
 
                 if (readBinary) databuf = appendBuffer(databuf, chunk);
@@ -238,20 +242,18 @@ module.exports = (function() {
                         gatherChunk(chunk);
                     }
 
-                    if (!readErr) {
-                        if (!readImmediate) {
-                            // 35% higher peak throughput with setTimeout (2800/s vs 2050)
-                            // 3x higher throughput per connection with setImmediate (1700/s vs 550)
-                            // +10% peak throughput when using qtimers (3000/s, 2300/s)
-                            setTimeout(readloop, 1);
-                        }
-                        else {
-                            // Note: setImmediate internally can chew up lots of memory and perform poorly
-                            // in wrk -d8s -t2 -c8 throughput tests.  But then it performs better in kds
-                            // and in restify emulation mode; else it`s about even.
-                            // needs qtimers setImmediate else can trample the gc system
-                            setImmediate(readloop);
-                        }
+                    if (!readImmediate) {
+                        // 35% higher peak throughput with setTimeout (2800/s vs 2050)
+                        // 3x higher throughput per connection with setImmediate (1700/s vs 550)
+                        // +10% peak throughput when using qtimers (3000/s, 2300/s)
+                        setTimeout(readloop, 1);
+                    }
+                    else {
+                        // Note: setImmediate internally can chew up lots of memory and perform poorly
+                        // in wrk -d8s -t2 -c8 throughput tests.  But then it performs better in kds
+                        // and in restify emulation mode; else it`s about even.
+                        // needs qtimers setImmediate else can trample the gc system
+                        setImmediate(readloop);
                     }
                 }
             }
@@ -264,13 +266,13 @@ module.exports = (function() {
             req.on('error', function(err) {
                 req._bodyEof = true;
                 var msg = "error reading request body" + (req.restiq._opts.debug ? (": " + err.stack) : "");
-                if (next) next(new Restiq.errors.ErrorInternalServerError(msg));
+                returnOnce(new Restiq.errors.ErrorInternalServerError(msg));
             });
 
             req.on('end', function() {
                 req._bodyEof = true;
                 req.body = databuf || data /*|| (chunks ? Buffer.concat(chunks) : "")*/;
-                if (next) next(readErr);
+                returnOnce();
             });
         };
     };

--- a/lib/rlib.js
+++ b/lib/rlib.js
@@ -9,6 +9,7 @@ var querystring = require('querystring');
 var http_build_query = require('qhttp/http_build_query');
 var http_parse_query = require('qhttp/http_parse_query');
 var Restiq = require('./restiq');
+var bytes = require("bytes");
 
 module.exports = (function() {
     var paramDecoders = {
@@ -31,17 +32,29 @@ module.exports = (function() {
         'application/x-www-form-urlencoded':    function encodeForm(s) { return querystring.encode(s) },
     };
 
+    // Making all mw available as factories for consistency.
     return {
-        parseQueryParams: parseQueryParams,
-        skipBody: skipBody,
-        readBody: readBody,
-        parseBody: parseBody,
-        parseBodyParams: parseBodyParams,
-        parseRouteParams: parseRouteParams,
-        parseAuthorization: parseAuthorization,
-        closeResponse: closeResponse,
+        discardBody: buildDiscardBody(),
+        parseQueryParams: buildParseQueryParams(),
+        skipBody: buildSkipBody(),
+        readBody: buildReadBody(),
+        parseBody: buildParseBody(),
+        parseBodyParams: buildParseBodyParams(),
+        parseRouteParams: buildParseRouteParams(),
+        parseAuthorization: buildParseAuthorization(),
+        closeResponse: buildCloseResponse(),
 
         getDefaultResponseEncoders: function() { return responseEncoders },
+
+        buildDiscardBody: buildDiscardBody,
+        buildParseQueryParams: buildParseQueryParams,
+        buildSkipBody: buildSkipBody,
+        buildReadBody: buildReadBody,
+        buildParseBody: buildParseBody,
+        buildParseBodyParams: buildParseBodyParams,
+        buildParseRouteParams: buildParseRouteParams,
+        buildParseAuthorization: buildParseAuthorization,
+        buildCloseResponse: buildCloseResponse,
     };
 
     function _tryDecodeQuery( queryString, params ) {
@@ -49,15 +62,18 @@ module.exports = (function() {
         catch (e) { return new Restiq.errors.ErrorBadRequest("error decoding query params: " + e.message); }
     }
 
-    function parseQueryParams( req, res, next ) {
-        var err, qmark, queryParams = {};
-        if ((qmark = req.url.indexOf('?')) >= 0) {
-            var hmark = req.url.indexOf('#');
-            if (hmark < 0) hmark = req.url.length;
-            err = _tryDecodeQuery(req.url.slice(qmark+1, hmark), req.query = {});
-            for (var i in req.query) req.params[i] = req.query[i];
-        }
-        if (next) next(err);
+    function buildParseQueryParams() {
+        return function parseQueryParams( req, res, next ) {
+            var err, qmark, queryParams = {};
+
+            if ((qmark = req.url.indexOf('?')) >= 0) {
+                var hmark = req.url.indexOf('#');
+                if (hmark < 0) hmark = req.url.length;
+                err = _tryDecodeQuery(req.url.slice(qmark+1, hmark), req.query = {});
+                for (var i in req.query) req.params[i] = req.query[i];
+            }
+            if (next) next(err);
+        };
     };
 
     // decode body, or return err
@@ -68,185 +84,237 @@ module.exports = (function() {
     }
 
     // parse message body and store resulting object in req.body
-    function parseBody( req, res, next ) {
-        function isBase64( str, limit ) {
-            var charp = str.charCodeAt ? str.charCodeAt : function(i) { return str[i] };
-            var len = Math.min(limit, str.length);
-            for (var i=0; i<len; i++) {
-                // checks that all characters in the string are valid base64
-                // effectively, str.match(/^[0-9a-fA-F+\/\r\n/]*[=\r\n]*$/)
-                var c = charp(i);
-                if (!(c >= 0x30 && c <= 0x39 ||         // [0-9]
-                      c >= 0x41 && c <= 0x5a ||         // [A-Z]
-                      c >= 0x61 && c <= 0x7a ||         // [a-z]
-                      c === 0x2b ||                     // [+]
-                      c === 0x2f ||                     // [/]
-                      c === 0x3d ||                     // [=]
-                      c === 0x0d ||                     // [\r]
-                      c === 0x0a))                      // [\n]
-                    return false;
-            }
-            return true;
-        }
-
-        module.exports.readBody(req, res, function(err) {
-            if (err) return next ? next(err) : null;
-            if (!err) {
-                // FIXME: we key off Content-Type to determine how to decode,
-                // but this should be exposed and configurable via the app
-                var type = req.headers['content-type'];
-// FIXME: tentative: content-type auto-detection
-                if (!type) {
-                    // auto-detect type based on content if no content-type
-                    if (req.body[0] === '{' || req.body[0] === 0x7b) type = 'application/json';
-                    else if (req.body[0] === '[' || req.body[0] === 0x5b) type = 'application/octet-stream';
-                    else if (isBase64(req.body, 2000)) type = 'base64';
-                    else type = 'application/octet-stream';
+    function buildParseBody(options) {
+        return function parseBody( req, res, next ) {
+            function isBase64( str, limit ) {
+                var charp = str.charCodeAt ? str.charCodeAt : function(i) { return str[i] };
+                var len = Math.min(limit, str.length);
+                for (var i=0; i<len; i++) {
+                    // checks that all characters in the string are valid base64
+                    // effectively, str.match(/^[0-9a-fA-F+\/\r\n/]*[=\r\n]*$/)
+                    var c = charp(i);
+                    if (!(c >= 0x30 && c <= 0x39 ||         // [0-9]
+                          c >= 0x41 && c <= 0x5a ||         // [A-Z]
+                          c >= 0x61 && c <= 0x7a ||         // [a-z]
+                          c === 0x2b ||                     // [+]
+                          c === 0x2f ||                     // [/]
+                          c === 0x3d ||                     // [=]
+                          c === 0x0d ||                     // [\r]
+                          c === 0x0a))                      // [\n]
+                        return false;
                 }
-                if (type !== 'text/plain') {
-                    err = _tryDecodeBody(req, type);
-                }
+                return true;
             }
-            if (next) next(err);
-        });
-    }
 
-    function parseBodyParams( req, res, next ) {
-        if (!req._bodyEof) {
-            // if body has not been read yet, read it first
-            module.exports.readBody(req, res, function(err) {
+            module.exports.buildReadBody(options)(req, res, function(err) {
                 if (err) return next ? next(err) : null;
-                parseBodyParams(req, res, next);
+                if (!err) {
+                    // FIXME: we key off Content-Type to determine how to decode,
+                    // but this should be exposed and configurable via the app
+                    var type = req.headers['content-type'];
+                    // FIXME: tentative: content-type auto-detection
+                    if (!type) {
+                        // auto-detect type based on content if no content-type
+                        if (req.body[0] === '{' || req.body[0] === 0x7b) type = 'application/json';
+                        else if (req.body[0] === '[' || req.body[0] === 0x5b) type = 'application/octet-stream';
+                        else if (isBase64(req.body, 2000)) type = 'base64';
+                        else type = 'application/octet-stream';
+                    }
+                    if (type !== 'text/plain') {
+                        err = _tryDecodeBody(req, type);
+                    }
+                }
+                if (next) next(err);
             });
         }
-        else {
-            // FIXME: we key off Content-Type to determine how to decode,
-            // but this should be exposed and configurable via the app
-            var err, type = req.headers && req.headers['content-type'] || 'text/plain';
-            try { decodeBody(type, req.body, req.params); }
-            catch (e) { err = new Restiq.errors.ErrorBadRequest("error decoding body params"); }
-            if (next) next(err);
-        }
     };
 
-    function parseRouteParams( req, res, next ) {
-        // module params were extracted with the route match regex, transcribe them
-        var i, params = req.params, vars = req._route.vars;
-        for (i in vars) params[i] = http_parse_query.urldecode(vars[i]);
-        if (next) next();
-    };
+    // Consumes request data immediately so the end event is fired.
+    // Data gathered is ignored.
+    function buildDiscardBody() {
+        return function discardBody( req, res, next ) {
+            req.on('data', function() {});
+            req.on('error', function(err) {
+                req._bodyEof = true;
+                var msg = "Error atempting to dispose the request body" + (req.restiq._opts.debug ? (": " + err.stack) : "");
+                if (next) next(new Restiq.errors.ErrorInternalServerError(msg));
+            });
+            req.on('end', function() {
+                req._bodyEof = true;
+                if (next) next();
+            });
+        };
+    }
 
-    function skipBody( req, res, next ) {
-        // CAUTION: only use if can guarantee that there is no body
-        // (eg, when used in strictly controlled environment)
-        req.body = "";
-        req._bodyEof = true;
-        if (next) next();
-    };
-
-    function readBody( req, res, next ) {
-        // body is read only once ever, and _bodyEof is the mutex
-        if (req._bodyEof !== undefined) return next ? next() : null;
-        req._bodyEof = false;
-
-        var data = "";
-        var databuf;
-        //var chunks = new Array();
-        var readBinary = req.restiq._opts.readBinary;
-        var readImmediate = req.restiq._opts.readImmediate;
-
-        // have the system deal with not splitting multi-byte chars
-        if (!readBinary) req.setEncoding('utf8');
-
-        // default to on('data'), not the fastest but more versatile
-        // 2 is 15% less max throughput than 0 and 10% slower than 1,
-        // but scales down better than 0 and doesnt affect gc like 1
-        if (readImmediate === undefined) readImmediate = 2;
-
-        function appendBuffer( databuf, chunk ) {
-            // TODO: if (databuf) impose maxBodySize and error out if too big
-            return databuf ? databuf.concat([databuf, chunk]) : chunk;
-            // TODO: find an efficient way of combining contents,
-            // eg preallocate space and copy data into it.
-        }
-        function gatherChunk(chunk) {
-            // NOTE: it is faster to concat strings than to push the buffers
-            // NOTE: toString('binary') is not binary, it converts from latin-1
-            if (readBinary) databuf = appendBuffer(databuf, chunk);
-            else data += chunk;
-            //else chunks.push(chunk);
-        }
-        function readloop() {
+    function buildParseBodyParams(options) {
+        return function parseBodyParams( req, res, next ) {
             if (!req._bodyEof) {
-                var chunk = req.read();
-                if (chunk) {
-                    //gatherChunk(chunk);
-                    if (readBinary) gatherChunk(chunk);
-                    else data += chunk;
+                // if body has not been read yet, read it first
+                module.exports.buildReadBody(options)(req, res, function(err) {
+                    if (err) return next ? next(err) : null;
+                    parseBodyParams(req, res, next);
+                });
+            }
+            else {
+                // FIXME: we key off Content-Type to determine how to decode,
+                // but this should be exposed and configurable via the app
+                var err, type = req.headers && req.headers['content-type'] || 'text/plain';
+                try { decodeBody(type, req.body, req.params); }
+                catch (e) { err = new Restiq.errors.ErrorBadRequest("error decoding body params"); }
+                if (next) next(err);
+            }
+        };
+    };
+
+    function buildParseRouteParams() {
+        return function parseRouteParams( req, res, next ) {
+            // module params were extracted with the route match regex, transcribe them
+            var i, params = req.params, vars = req._route.vars;
+            for (i in vars) params[i] = http_parse_query.urldecode(vars[i]);
+            if (next) next();
+        };
+    };
+
+    function buildSkipBody() {
+        return function skipBody( req, res, next ) {
+            // CAUTION: only use if can guarantee that there is no body
+            // (eg, when used in strictly controlled environment)
+            req.body = "";
+            req._bodyEof = true;
+            if (next) next();
+        }
+    };
+
+
+    function buildReadBody(options) {
+        options = options || {};
+
+        // Default maxBodySize to 100kb if not passed in.
+        // If it is not a number send it to bytes for parsing.
+        if (typeof options.maxBodySize !== "number") {
+            options.maxBodySize = bytes.parse(options.maxBodySize || "100kb");
+        }
+
+        return function readBody( req, res, next ) {
+            // body is read only once ever, and _bodyEof is the mutex
+            if (req._bodyEof !== undefined) return next ? next() : null;
+            req._bodyEof = false;
+
+            var readErr;
+            var bytesReceived = 0;
+            var data = "";
+            var databuf;
+            //var chunks = new Array();
+            var readBinary = req.restiq._opts.readBinary;
+            var readImmediate = req.restiq._opts.readImmediate;
+
+            // have the system deal with not splitting multi-byte chars
+            if (!readBinary) req.setEncoding('utf8');
+
+            // default to on('data'), not the fastest but more versatile
+            // 2 is 15% less max throughput than 0 and 10% slower than 1,
+            // but scales down better than 0 and doesnt affect gc like 1
+            if (readImmediate === undefined) readImmediate = 2;
+
+            function appendBuffer( databuf, chunk ) {
+                return databuf ? databuf.concat([databuf, chunk]) : chunk;
+                // TODO: find an efficient way of combining contents,
+                // eg preallocate space and copy data into it.
+            }
+            function gatherChunk(chunk) {
+                // NOTE: it is faster to concat strings than to push the buffers
+                // NOTE: toString('binary') is not binary, it converts from latin-1
+                bytesReceived += chunk.length;
+
+                if (bytesReceived > options.maxBodySize) {
+                    req._bodyEof = true;
+                    readErr = new Restiq.errors.ErrorBadRequest('Error reading body, max request body size exceeded.');
+
+                    return;
                 }
-                if (!readImmediate) {
-                    // 35% higher peak throughput with setTimeout (2800/s vs 2050)
-                    // 3x higher throughput per connection with setImmediate (1700/s vs 550)
-                    // +10% peak throughput when using qtimers (3000/s, 2300/s)
-                    setTimeout(readloop, 1);
-                }
-                else {
-                    // Note: setImmediate internally can chew up lots of memory and perform poorly
-                    // in wrk -d8s -t2 -c8 throughput tests.  But then it performs better in kds
-                    // and in restify emulation mode; else it`s about even.
-                    // needs qtimers setImmediate else can trample the gc system
-                    setImmediate(readloop);
+
+                if (readBinary) databuf = appendBuffer(databuf, chunk);
+                else data += chunk;
+                //else chunks.push(chunk);
+            }
+            function readloop() {
+                if (!req._bodyEof) {
+                    var chunk = req.read();
+
+                    if (chunk) {
+                        gatherChunk(chunk);
+                    }
+
+                    if (!readErr) {
+                        if (!readImmediate) {
+                            // 35% higher peak throughput with setTimeout (2800/s vs 2050)
+                            // 3x higher throughput per connection with setImmediate (1700/s vs 550)
+                            // +10% peak throughput when using qtimers (3000/s, 2300/s)
+                            setTimeout(readloop, 1);
+                        }
+                        else {
+                            // Note: setImmediate internally can chew up lots of memory and perform poorly
+                            // in wrk -d8s -t2 -c8 throughput tests.  But then it performs better in kds
+                            // and in restify emulation mode; else it`s about even.
+                            // needs qtimers setImmediate else can trample the gc system
+                            setImmediate(readloop);
+                        }
+                    }
                 }
             }
-        }
-        // consume data to trigger the 'end' event
-        // read() is 40% quicker than on('data') (v0.10.29)
-        // TODO: time out after some amount of inactivity!
-        if (readImmediate == 2) req.on('data', gatherChunk);
-        else readloop();
+            // consume data to trigger the 'end' event
+            // read() is 40% quicker than on('data') (v0.10.29)
+            // TODO: time out after some amount of inactivity!
+            if (readImmediate == 2) req.on('data', gatherChunk);
+            else readloop();
 
-        req.on('error', function(err) {
-            req._bodyEof = true;
-            var msg = "error reading request body" + (req.restiq._opts.debug ? (": " + err.stack) : "");
-            if (next) next(new Restiq.errors.ErrorInternalServerError(msg));
-        });
+            req.on('error', function(err) {
+                req._bodyEof = true;
+                var msg = "error reading request body" + (req.restiq._opts.debug ? (": " + err.stack) : "");
+                if (next) next(new Restiq.errors.ErrorInternalServerError(msg));
+            });
 
-        req.on('end', function() {
-            req._bodyEof = true;
-            req.body = databuf || data /*|| (chunks ? Buffer.concat(chunks) : "")*/;
-            if (next) next();
-        });
+            req.on('end', function() {
+                req._bodyEof = true;
+                req.body = databuf || data /*|| (chunks ? Buffer.concat(chunks) : "")*/;
+                if (next) next(readErr);
+            });
+        };
     };
 
     // restify compatible Basic auth header parsing
     // the auth info is stored in req.authorization.basic and req.authorization.username
-    function parseAuthorization( req, res, next ) {
-        var auth = req.headers['authorization'];
-        if (!auth) return next();
-        var parts = auth.split(' ');
-        if (parts[0] === 'Basic' || parts.toLowerCase[0] === 'basic') {
-            var nameval = new Buffer(parts[1], 'base64');
-            for (var i=0; i<nameval.length; i++) if (nameval[i] === ':'.charCodeAt(0)) break;
-            var user = nameval.slice(0, i).toString();
-            var pass = nameval.slice(i+1).toString();
-            req.username = user;
-            req.authorization = { basic: { username: user, password: pass } };
-        }
-        else if (parts[0] === 'Signature' || parts[0].toLowerCase() === 'signature') {
-            // TODO: not supported yet
-        }
-        next();
+    function buildParseAuthorization() {
+        return function parseAuthorization( req, res, next ) {
+            var auth = req.headers['authorization'];
+            if (!auth) return next();
+            var parts = auth.split(' ');
+            if (parts[0] === 'Basic' || parts.toLowerCase[0] === 'basic') {
+                var nameval = new Buffer(parts[1], 'base64');
+                for (var i=0; i<nameval.length; i++) if (nameval[i] === ':'.charCodeAt(0)) break;
+                var user = nameval.slice(0, i).toString();
+                var pass = nameval.slice(i+1).toString();
+                req.username = user;
+                req.authorization = { basic: { username: user, password: pass } };
+            }
+            else if (parts[0] === 'Signature' || parts[0].toLowerCase() === 'signature') {
+                // TODO: not supported yet
+            }
+            next();
+        };
     }
 
     // forcibly flush the response if necessary end the connection
-    function closeResponse( req, res, next ) {
-        if (!res.headersSent) {
-            if (res.body === undefined) res.body = "";
-            if (typeof res.body !== 'string') res.body = JSON.stringify(res.body);
-            res.end(res.body);
-        }
-        if (next) next();
-    };
+    function buildCloseResponse() {
+        return function closeResponse( req, res, next ) {
+            if (!res.headersSent) {
+                if (res.body === undefined) res.body = "";
+                if (typeof res.body !== 'string') res.body = JSON.stringify(res.body);
+                res.end(res.body);
+            }
+            if (next) next();
+        };
+    }
 
     function decodeBody( type, str, params ) {
         var ps, decode = paramDecoders[type];

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "express"
   ],
   "dependencies": {
-    "qhttp": "0.0.6",
-    "aflow": "0.10.1"
+    "aflow": "0.10.1",
+    "bytes": "^2.4.0",
+    "qhttp": "0.0.6"
   },
   "devDependencies": {
     "qmock": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "dependencies": {
     "aflow": "0.10.1",
-    "bytes": "^2.4.0",
     "qhttp": "0.0.6"
   },
   "devDependencies": {

--- a/test/test-restiq.js
+++ b/test/test-restiq.js
@@ -17,6 +17,9 @@ module.exports = {
             t.ok(Restiq.mw.parseQueryParams);
             t.ok(Restiq.mw.parseBodyParams);
             t.ok(Restiq.mw.readBody);
+            t.ok(Restiq.mw.buildParseQueryParams());
+            t.ok(Restiq.mw.buildParseBodyParams());
+            t.ok(Restiq.mw.buildReadBody());
             t.done();
         },
 
@@ -95,6 +98,49 @@ module.exports = {
                 t.done();
             });
         },
+
+        'should dispose of body': function(t) {
+            req = new http.IncomingMessage();
+            req.push("Not going to use this");
+            req.push(null);
+            // Simulating setEncoding since that is not available on the mock.
+            t.expect(1);
+            Restiq.mw.discardBody(req, {}, function(err) {
+                t.ok(!err);
+                t.done();
+            });
+        },
+
+        'should sucessfully read body as a string': function(t) {
+            req = new http.IncomingMessage();
+            req.restiq = {
+                _opts: {}
+            };
+            req.push("Just some data bro");
+            req.push(null);
+            t.expect(1);
+            Restiq.mw.readBody(req, {}, function(err) {
+                t.ok(!err);
+                t.done();
+            });
+        },
+
+        'should fail to parse body due to maxBodySize being exceeded': function(t) {
+            req = new http.IncomingMessage();
+            req.restiq = {
+                _opts: {
+                    readBinary: true
+                }
+            };
+            req.push("Just some data bro");
+            req.push(null);
+            t.expect(2);
+            Restiq.mw.buildReadBody({maxBodySize: 1})(req, {}, function(err) {
+                t.ok(err);
+                t.equal(err.message, 'Error reading body, max request body size exceeded.');
+                t.done();
+            });
+        }
     },
 
     'restiq app setup': {


### PR DESCRIPTION
Hello!

We recently ran into a situation where we needed to limit the request body size. This of course required options be passed to readBody which required a factory of some kind. For consistency, I wrapped all middleware in factories. `restiq.mw` still exposes direct access to the middleware.

The changes I made enumerated:
* Wrapped all middleware in factories following a consistent naming convention. Ex. `buildReadBody`.
* restiq.mw.readBody enforces a max request size which defaults to 100kb.
* Added a dependency on bytes to parse strings given as maxBodySize. I point this out because this may be a point of contention. Perhaps we should just require a number that represents the number of bytes.
* Updated and added unit tests.
* This is somewhat unrelated but we thought it would be helpful to have a discardBody middleware. I replaced two uses of readBody with discardBody because they were only being used to consume the entire request body to force the end event to fire. Please correct me if this was improper usage.
* Finally I updated the docs.

The end goal of all of this was so we could enforce a max body size but it sort of snow balled. No rush on this pull request and feel free to disagree with any of the solutions provided.

Thanks!!